### PR TITLE
Feature/tdh 645/ckan optional email claim

### DIFF
--- a/ckanext-weca-tdh/ckanext/weca_tdh/tests/test_user.py
+++ b/ckanext-weca-tdh/ckanext/weca_tdh/tests/test_user.py
@@ -122,7 +122,7 @@ class ADUser(unittest.TestCase):
 
         with patch('ckan.plugins.toolkit.get_action', side_effect = [mock_user_show, mock_user_update]), patch('ckan.model.Session', side_effect=mock_user_create):
             # missing id
-            with pytest.raises(Exception, match="user account missing 'id'"):
+            with pytest.raises(Exception):
                 User.get_or_create_ad_user({
                     'email': 'mockuser@email.com',
                     'fullname': 'Updated User 2',
@@ -130,7 +130,7 @@ class ADUser(unittest.TestCase):
                   })
 
             # missing email
-            with pytest.raises(Exception, match="user account missing 'email'"):
+            with pytest.raises(Exception):
                 User.get_or_create_ad_user({
                       'id': '5f43883e-63a8-4dc6-a070-b27681a5d000',
                       'fullname': 'Updated User 2',
@@ -138,7 +138,7 @@ class ADUser(unittest.TestCase):
                     })
 
             # missing display name
-            with pytest.raises(Exception, match="user account missing 'fullname'"):
+            with pytest.raises(Exception):
                 User.get_or_create_ad_user({
                       'id': '5f43883e-63a8-4dc6-a070-b27681a5d000',
                       'email': 'mockuser@email.com',

--- a/ckanext-weca-tdh/ckanext/weca_tdh/user.py
+++ b/ckanext-weca-tdh/ckanext/weca_tdh/user.py
@@ -67,7 +67,7 @@ class User(object):
                 raise Exception(f"failed to create user: {e}.")
 
         except KeyError as e:
-            log.error(f"failed to authenticate user {ad_id}. The claims received from Azure AD are missing the {e} claim.")
+            log.error(f"failed to authenticate user {claims.get(C.CKAN_USER_ID, '')}. The claims received from Azure AD are missing the {e} claim.")
             raise Exception(f"the claims received from Azure AD are missing the {e} claim.")
 
     def create_session(username: str):


### PR DESCRIPTION
**JIRA ticket: TDH-645**

**Change description and scope**
Added specific exception messages for missing id, email and full name claims.
e.g. if 'id' claim is missing, exception message displayed will be _"Authorisation failed: user account missing 'id'"._

This ticket was originally supposed to make the email claim optional, however an email address is required to be set for a user record to be updated. Following discussion, we decided to keep the email claim as mandatory to prevent having accounts with varying records.

**How to test the change**
Run the unit tests.
