### PR TITLE
Set CKAN logging levels to WARNING

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vscode/settings.json

--- a/ckanext-weca-tdh/docker/ckan/setup/start_ckan.sh.override
+++ b/ckanext-weca-tdh/docker/ckan/setup/start_ckan.sh.override
@@ -107,6 +107,10 @@ ckan config-tool $CKAN_INI "ad.group.sysadmin_id = $AD_USER_GROUP_SYSADMIN_ID"
 # Set Cookie Control API key
 ckan config-tool $CKAN_INI "ccc.api_key = $CCC_API_KEY" 
 
+# Configure logging
+ckan config-tool $CKAN_INI --section logger_ckan "level = WARNING"
+ckan config-tool $CKAN_INI --section logger_ckanext "level = WARNING"
+
 # Run the prerun script to init CKAN and create the default admin user
 python3 prerun.py
 

--- a/ckanext-weca-tdh/docker/ckan/setup/start_ckan_development.sh.override
+++ b/ckanext-weca-tdh/docker/ckan/setup/start_ckan_development.sh.override
@@ -120,6 +120,10 @@ ckan config-tool $SRC_DIR/ckan/test-core.ini \
     "solr_url = $TEST_CKAN_SOLR_URL" \
     "ckan.redis.url = $TEST_CKAN_REDIS_URL"
 
+# Configure logging
+ckan config-tool $CKAN_INI --section logger_ckan "level = WARNING"
+ckan config-tool $CKAN_INI --section logger_ckanext "level = WARNING"
+
 # Run the prerun script to init CKAN and create the default admin user
 python3 prerun.py
 


### PR DESCRIPTION
**JIRA ticket:** TDH-674

**Change description and scope**
Set logging levels to WARNING. See https://stackoverflow.com/questions/35782876/ckan-disabling-logging-info-message-datastore-search-action-render-time

**How to test the change**
View the log file - should have no Rendering time DEBUG logging any more.

**How to run tests if out of ordinary (optional)**
N/a

**Particular areas reviewer should look carefully at**
N/a

**Has the code been formatted correctly (matches CKAN guidelines/PEP 8)?**
N/a

**Has the code been linted (pylint, flake8, mypy)?**
N/a