### PR TITLE
Feature/tdh 815/ckan update username generation

### DIFF
--- a/ckanext-weca-tdh/ckanext/weca_tdh/user.py
+++ b/ckanext-weca-tdh/ckanext/weca_tdh/user.py
@@ -94,7 +94,8 @@ class User(object):
             username = f"{ckname}{n}-{ckdomain}"
             if User._validate_username(username):
                 return username
-            
+
+        # would only occur if CKAN enforce new constaints
         raise Exception("invalid username constraints")
 
     def _validate_username(username):


### PR DESCRIPTION
**JIRA ticket: TDH-815**

**Change description and scope**
Updated the username generation function to follow the new logic described in the [ticket](https://westofenglandca.atlassian.net/jira/software/projects/TDH/boards/1?assignee=630e0f298473817d7d0427ea&selectedIssue=TDH-815).

**How to test the change**
Tested using emails of varying degrees of obscurity from AD.
Run the unit tests or create a new account and check the username is as expected.