### PR TITLE
Update resource link to open in new tab

### DIFF
--- a/ckanext-weca-tdh/ckanext/weca_tdh/templates/package/resource_read.html
+++ b/ckanext-weca-tdh/ckanext/weca_tdh/templates/package/resource_read.html
@@ -7,3 +7,35 @@
     {{ super() }}
   </div>
 {% endblock %}
+
+{% block resource_actions_inner %}
+  {% block action_manage %}
+    {{ super() }}
+  {% endblock %}
+  <li>
+    <div class="btn-group">
+      {% block button_group %}
+        {% if res.url and h.is_url(res.url) %}
+          {% set target = "_blank" if not res.resource_type in ('listing', 'service', 'api') and not res.has_views and not res.url_type == 'upload' else "" %}
+          <a class="btn btn-primary resource-url-analytics" href="{{ res.url }}" target="{{target}}">
+            {% if res.resource_type in ('listing', 'service') %}
+              <i class="fa fa-eye"></i> {{ _('View') }}
+            {% elif  res.resource_type == 'api' %}
+              <i class="fa fa-key"></i> {{ _('API Endpoint') }}
+            {% elif not res.has_views and not res.url_type == 'upload' %}
+              <i class="fa fa-external-link"></i> {{ _('Go to resource') }}
+            {% else %}
+              <i class="fa fa-arrow-circle-down"></i> {{ _('Download') }}
+            {% endif %}  
+          </a>
+        {% endif %}
+        {% block download_resource_button %}
+          {{ super() }}
+        {% endblock %}
+      {% endblock %}
+    </div>
+  </li>
+  {% if res.datastore_active %}
+    <li>{% snippet 'package/snippets/data_api_button.html', resource=res %}</li>
+  {% endif %}
+{% endblock %}

--- a/ckanext-weca-tdh/ckanext/weca_tdh/templates/package/snippets/resource_row_item.html
+++ b/ckanext-weca-tdh/ckanext/weca_tdh/templates/package/snippets/resource_row_item.html
@@ -57,11 +57,17 @@
               {% if res.url and h.is_url(res.url) %}
                 <li>
                   <a class="dropdown-item resource-url-analytics" href="{{ res.url }}" target="_blank" rel="noreferrer">
-                    <i class="fa fa-external-link"></i>
-                    {{ _('Go to resource') }}
+                    {% if res.url_type != 'upload' %}
+                      <i class="fa fa-external-link"></i>
+                      {{ _('Go to resource') }}
+                    {% else %}
+                      <i class="fa fa-arrow-circle-down"></i>
+                      {{ _('Download') }}
+                    {% endif %}
                   </a>
                 </li>
               {% endif %}
+
               {% if can_edit %}
                 <li>{% link_for _('Edit resource'), named_route=pkg.type ~ '_resource.edit', id=pkg.name, resource_id=res.id, class_='dropdown-item', icon='pencil' %}</li>
               {% endif %}


### PR DESCRIPTION
**JIRA ticket: TDH-884**

**Change description and scope**
Implemented UAT feedback to make hyperlinks open in a new tab.
Fixed a bug where a direct download link would incorrectly read 'Go to resource'.

**How to test the change**
Live on dev and preprod.

