### PR TITLE
Remove truncation limit on link name

### DIFF
--- a/ckanext-weca-tdh/ckanext/weca_tdh/templates/package/snippets/resource_row_item.html
+++ b/ckanext-weca-tdh/ckanext/weca_tdh/templates/package/snippets/resource_row_item.html
@@ -15,7 +15,7 @@
 {% block resource_item %}
   <tr class="govuk-table__row">
     <td class="govuk-table__cell">
-      <a class="govuk-link" href="{{ url }}">{{ h.resource_display_name(res) | truncate(100) }}</a>
+      <a class="govuk-link" href="{{ url }}">{{ h.resource_display_name(res) | truncate(75) }}</a>
     </td>
     <td class="govuk-table__cell">
       {{ res.format or 'Data' }}

--- a/ckanext-weca-tdh/ckanext/weca_tdh/templates/package/snippets/resource_row_item.html
+++ b/ckanext-weca-tdh/ckanext/weca_tdh/templates/package/snippets/resource_row_item.html
@@ -15,7 +15,7 @@
 {% block resource_item %}
   <tr class="govuk-table__row">
     <td class="govuk-table__cell">
-      <a class="govuk-link" href="{{ url }}">{{ h.resource_display_name(res) }}</a>
+      <a class="govuk-link" href="{{ url }}">{{ h.resource_display_name(res) | truncate(100) }}</a>
     </td>
     <td class="govuk-table__cell">
       {{ res.format or 'Data' }}

--- a/ckanext-weca-tdh/ckanext/weca_tdh/templates/package/snippets/resource_row_item.html
+++ b/ckanext-weca-tdh/ckanext/weca_tdh/templates/package/snippets/resource_row_item.html
@@ -15,7 +15,7 @@
 {% block resource_item %}
   <tr class="govuk-table__row">
     <td class="govuk-table__cell">
-      <a class="govuk-link" href="{{ url }}">{{ h.resource_display_name(res) | truncate(50) }}</a>
+      <a class="govuk-link" href="{{ url }}">{{ h.resource_display_name(res) }}</a>
     </td>
     <td class="govuk-table__cell">
       {{ res.format or 'Data' }}


### PR DESCRIPTION
**JIRA ticket:**
https://westofenglandca.atlassian.net/browse/TDH-3294

**Change description and scope**
Removed the 50 char limit on names shown on the Dataset page/resource table

This has annoyed me for a long time
<img width="913" height="399" alt="image" src="https://github.com/user-attachments/assets/005de9a4-ee6a-484f-a654-88deb566446d" />

<img width="417" height="243" alt="image" src="https://github.com/user-attachments/assets/e6487504-fab1-4634-a08a-3145daa43887" />

**How to test the change**
Create a resource containing a long name

