### PR TITLE
Changing Support to Documentation

### DIFF
--- a/ckanext-weca-tdh/ckanext/weca_tdh/config.py
+++ b/ckanext-weca-tdh/ckanext/weca_tdh/config.py
@@ -62,7 +62,7 @@ UPLOAD_STATUS_FAILED = "Failed to upload file."
 
 contact_email = config.get('tdh.contact_email') or 'ftz@westofengland-ca.gov.uk'
 ALERT_MESSAGE_SUPPORT_EMAIL = f"Contact support by emailing <a href='mailto:{contact_email}'>{contact_email}</a>"
-ALERT_MESSAGE_SUPPORT = f"See the <a href='/pages/support'><u>Support Page</u></a> for assistance raising a new issue on Hornbill, quoting this error message"
+ALERT_MESSAGE_SUPPORT = f"See the <a href='/pages/master-support-page'><u>Support Page</u></a> for assistance raising a new issue on Hornbill, quoting this error message"
 
 # Cookie Control config
 CCC_API_KEY = config['ccc.api_key']

--- a/ckanext-weca-tdh/ckanext/weca_tdh/templates/ckanext_pages/edit_base.html
+++ b/ckanext-weca-tdh/ckanext/weca_tdh/templates/ckanext_pages/edit_base.html
@@ -1,3 +1,3 @@
 {% ckan_extends %}
 
-{% block subtitle %}{{ _('Support') }}{% endblock %}
+{% block subtitle %}{{ _('Documentation') }}{% endblock %}

--- a/ckanext-weca-tdh/ckanext/weca_tdh/templates/ckanext_pages/page.html
+++ b/ckanext-weca-tdh/ckanext/weca_tdh/templates/ckanext_pages/page.html
@@ -3,7 +3,7 @@
 {% block subtitle %}{{ c.page.title }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li class="active">{% link_for _('Support'), named_route='pages.pages_index' %}</li>
+  <li class="active">{% link_for _('Documentation'), named_route='pages.pages_index' %}</li>
   <li class="active">{% link_for c.page.title, named_route='pages.show', page=c.page.name %}</li>
 {% endblock %}
 

--- a/ckanext-weca-tdh/ckanext/weca_tdh/templates/ckanext_pages/page_edit.html
+++ b/ckanext-weca-tdh/ckanext/weca_tdh/templates/ckanext_pages/page_edit.html
@@ -3,7 +3,7 @@
 {% block subtitle %}{{ _('Edit Page')}} {% endblock %}
 
 {% block breadcrumb_content %}
-  <li class="active">{% link_for _('Support'), named_route='pages.pages_index' %}</li>
+  <li class="active">{% link_for _('Documentation'), named_route='pages.pages_index' %}</li>
   {% if data.title %}
     <li class="active">{% link_for data.title, named_route='pages.show', page=page %}</li>
     <li class="active">{% link_for _('Edit'), named_route='pages.edit', page=page %}</li>

--- a/ckanext-weca-tdh/ckanext/weca_tdh/templates/ckanext_pages/page_revisions.html
+++ b/ckanext-weca-tdh/ckanext/weca_tdh/templates/ckanext_pages/page_revisions.html
@@ -1,7 +1,7 @@
 {% ckan_extends %}
 
 {% block breadcrumb_content %}
-  <li class="active">{% link_for _('Support'), named_route='pages.pages_index' %}</li>
+  <li class="active">{% link_for _('Documentation'), named_route='pages.pages_index' %}</li>
   <li class="active">{% link_for c.page.title, named_route='pages.show', page=c.page.name %}</li>
   <li class="active">{% link_for _('Revisions'), named_route='pages.pages_revisions', page=c.page.name %}</li>
 {% endblock %}

--- a/ckanext-weca-tdh/ckanext/weca_tdh/templates/ckanext_pages/pages_list.html
+++ b/ckanext-weca-tdh/ckanext/weca_tdh/templates/ckanext_pages/pages_list.html
@@ -1,7 +1,7 @@
 {% extends 'ckanext_pages/edit_base.html' %}
 
 {% block breadcrumb_content %}
-  <li class="active">{% link_for _('Support'), named_route='pages.pages_index' %}</li>
+  <li class="active">{% link_for _('Documentation'), named_route='pages.pages_index' %}</li>
 {% endblock %}
 
 {% block primary %}

--- a/ckanext-weca-tdh/ckanext/weca_tdh/templates/ckanext_pages/snippets/pages_list.html
+++ b/ckanext-weca-tdh/ckanext/weca_tdh/templates/ckanext_pages/snippets/pages_list.html
@@ -1,7 +1,7 @@
 {% set pages_total = pages|length %}
 {% set action = '{0}_show'.format(type) %}
 
-<h1>{{ title or "Articles" if type == "blog" else "Support" }}</h1>
+<h1>{{ title or "Articles" if type == "blog" else "Documentation" }}</h1>
 
 {% if pages %}
   {% macro render_page(page, pin) %}

--- a/ckanext-weca-tdh/ckanext/weca_tdh/templates/ckanext_pages/snippets/pages_list.html
+++ b/ckanext-weca-tdh/ckanext/weca_tdh/templates/ckanext_pages/snippets/pages_list.html
@@ -35,6 +35,6 @@
   {% endfor %}
 {% else %}
   <p class="empty">
-    {{ _('There are currently no articles.') if type == 'blog' else _('There are currently no support pages.') }}
+    {{ _('There are currently no articles.') if type == 'blog' else _('There is currently no documentation available.') }}
   </p>
 {% endif %}

--- a/ckanext-weca-tdh/ckanext/weca_tdh/templates/footer.html
+++ b/ckanext-weca-tdh/ckanext/weca_tdh/templates/footer.html
@@ -8,7 +8,7 @@
         <li><a href="{{ h.url_for('pages.show', page='cookies') }}">{{ _('Cookie Policy') }}</a></li>
         <li><a href="javascript:CookieControl.open()">{{ _('Cookie Settings') }}</a></li>
         <li><a href="{{ h.url_for('pages.show', page='faq') }}">{{ _('FAQ') }}</a></li>
-        <li><a href="{{ h.url_for('pages.pages_index') }}">{{ _('Support') }}</a></li>
+        <li><a href="{{ h.url_for('pages.pages_index') }}">{{ _('Documentation') }}</a></li>
         <li><a href="https://www.westofengland-ca.gov.uk/">{{ _('West of England Mayoral Combined Authority Website') }}</a></li>
     {% endblock %}
   </ul>

--- a/ckanext-weca-tdh/ckanext/weca_tdh/templates/header.html
+++ b/ckanext-weca-tdh/ckanext/weca_tdh/templates/header.html
@@ -103,7 +103,7 @@
         <a href="/group" class="{% if current_path.startswith('/group') %}nav-item-active{% endif %}">{{_('Topics')}}</a>
     </li>
     <li>
-      <a href="/pages" class="{% if current_path.startswith('/pages') %}nav-item-active{% endif %}">{{_('Support')}}</a>
+      <a href="/pages" class="{% if current_path.startswith('/pages') %}nav-item-active{% endif %}">{{_('Documentation')}}</a>
     </li>
   {% endblock %}
 {% endblock %}

--- a/ckanext-weca-tdh/ckanext/weca_tdh/templates/home/about.html
+++ b/ckanext-weca-tdh/ckanext/weca_tdh/templates/home/about.html
@@ -63,7 +63,7 @@
 
         <h3>{{ _('Who can use the TDH Data Catalogue?') }}</h3>
         <p>{{ _('The TDH Data Catalogue is available to all West of England Mayoral Combined Authority employees.') }}</p>
-        <p>{{ _('Some datasets require further permissions to be granted, more information can be found on the') }} <a href="/pages/support">{{ _('Support page') }}</a>.</p>
+        <p>{{ _('Some datasets require further permissions to be granted, more information can be found on the') }} <a href="/pages/support/master-support-page">{{ _('How to access data page') }}</a>.</p>
         <p>{{ _('The TDH aims to provide benefit to a wide range of people. The main focus is on providing value to staff and projects within the MCA, 
           however it also aims to provide value to the wider transport community, including:') }}</p>
         <ul>

--- a/ckanext-weca-tdh/ckanext/weca_tdh/templates/home/index.html
+++ b/ckanext-weca-tdh/ckanext/weca_tdh/templates/home/index.html
@@ -101,7 +101,7 @@
               'classes': 'action-button',
               'attributes': {'download': 'tdh-partner-connect.pbids', 'data-cy': 'connect-button'}
               }) }}
-              <p style="font-size: 16px;">{{ _('Click') }} <a class="govuk-link" href="/pages/tdh_partner_connect" 
+              <p style="font-size: 16px;">{{ _('Click') }} <a class="govuk-link" href="/pages/master-support-page" 
                 data-cy="connect-details">{{ _('here') }}</a> {{ _('for more details') }}</p>
             </div>
           </div>

--- a/ckanext-weca-tdh/ckanext/weca_tdh/templates/home/snippets/about_action.html
+++ b/ckanext-weca-tdh/ckanext/weca_tdh/templates/home/snippets/about_action.html
@@ -27,5 +27,5 @@
         }) }}
     {% endif %}
     <p style="font-size: 16px;">{{ _('Having issues? See the') }} <a style="color: white; text-decoration: underline;"
-        href="/pages/support" data-cy="support-details">{{ _('Support page') }}</a></p>
+        href="/pages/master-support-page" data-cy="support-details">{{ _('Support page') }}</a></p>
 </div>

--- a/ckanext-weca-tdh/ckanext/weca_tdh/templates/package/resource_read.html
+++ b/ckanext-weca-tdh/ckanext/weca_tdh/templates/package/resource_read.html
@@ -93,8 +93,8 @@
       {% block data_access %}
         {% if res.resource_data_access %}
           {{ data_access_macro.render(res, tdh_schema) }}
-          <p class="heading-small data-access-support-link">{{ _('To learn more about data access methods, visit the') }} 
-            <a class="govuk-link" href="{{ h.url_for('pages.show', page='support') ~ '#data-access' }}">{{ _('Support page') }}</a>.
+          <p class="heading-small data-access-support-link">{{ _('To learn more about data access methods, see the') }} 
+            <a class="govuk-link" href="{{ h.url_for('pages.show', page='master-support-page') }}">{{ _('Documentation') }}</a>.
           </p>
         {% else %}
           <p>{{ _('A data access type has not been assigned to this resource.') }}</p>

--- a/ckanext-weca-tdh/ckanext/weca_tdh/templates/user/edit.html
+++ b/ckanext-weca-tdh/ckanext/weca_tdh/templates/user/edit.html
@@ -5,7 +5,7 @@
     <h2 class="module-heading"><i class="fa fa-info-circle"></i> {{ _('Account Info') }}</h2>
     <div class="module-content">
       <p>{{ _('Your profile lets other TDH users know about who you are and what you do.') }}</p>
-      <p>{{ _('For more information, visit the') }} <a href="/pages/support">{{ _('Support page') }}</a>.</p>
+      <p>{{ _('For more information, visit the') }} <a href="/pages/master-support-page">{{ _('Support page') }}</a>.</p>
     </div>
   </section>
 {% endblock %}

--- a/ckanext-weca-tdh/ckanext/weca_tdh/templates/user/snippets/login_form.html
+++ b/ckanext-weca-tdh/ckanext/weca_tdh/templates/user/snippets/login_form.html
@@ -13,7 +13,7 @@
     </div>
   </div>
   <div class="login-support">
-    <p class="govuk-body-s">{{ _('For login issues and general support, visit the ') }} <a href="{{ h.url_for('pages.show', page='support') }}">{{ _('Support page') }}</a>.</p>
+    <p class="govuk-body-s">{{ _('For login issues and general support, visit the ') }} <a href="{{ h.url_for('pages.show', page='master-support-page') }}">{{ _('Support page') }}</a>.</p>
   </div>
 {% else %}
   {% set username_error = true if error_summary %}


### PR DESCRIPTION
Based on the UT2 testing from January, [TDH-3229](https://westofenglandca.atlassian.net/browse/TDH-3229) determined that we should change the wording of the Support page to Documentation. I've implemented this change on the support index page, and in the header and footer.

A separate Maintenance task [TDH-3364](https://westofenglandca.atlassian.net/browse/TDH-3364) has been spun off to fix incorrect references to the old Support page removed late last year - I'll cover those changes in this PR too once Kelvin has worked out what we need to do.